### PR TITLE
Used New Refresh Tokens instead of existing token when refreshing access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.3.2] - 2025-03-17
+
+### Bug Fixes
+
+- Moved the 5 minute Buffer from the Refresh Token Expiry Date Calculation to the Access Token Expiry Date Calculation to ensure the access
+  token is always up to date
+- Used newly given Refresh Token instead of existing Refresh Token after refreshing the access token to ensure the refresh token is always
+  up to date
+
 ## [0.3.1] - 2025-03-16
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "quickbooks-api",
 	"author": "JackNytely <jacknytely@gmail.com>",
 	"license": "MIT",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"description": "A modular TypeScript SDK for seamless integration with Intuit QuickBooks APIs. Provides robust authentication handling and future-ready foundation for accounting, payments, and commerce operations.",
 	"type": "module",
 	"main": "dist/app.js",

--- a/src/packages/auth/auth-provider.ts
+++ b/src/packages/auth/auth-provider.ts
@@ -404,20 +404,17 @@ export class AuthProvider {
 	 * @returns {Token} The parsed token
 	 */
 	private parseTokenResponse(response: TokenResponse, realmId: string): Token {
-		// Calculate the New Expiry Data with a 5 minute buffer
-		const newRefreshTokenExpiryDate = new Date(Date.now() + (response.x_refresh_token_expires_in - 300) * 1000);
+		// Calculate the New Expiry Data
+		const newRefreshTokenExpiryDate = new Date(Date.now() + response.x_refresh_token_expires_in * 1000);
 
-		// Calculate the Expiry Date for the Refresh Token
-		const refreshTokenExpiryDate = this.token?.refreshTokenExpiryDate || newRefreshTokenExpiryDate;
-
-		// Calculate the Expiry Date for the Access Token
-		const accessTokenExpiryDate = new Date(Date.now() + response.expires_in * 1000);
+		// Calculate the Expiry Date for the Access Token with a 5 minute buffer
+		const accessTokenExpiryDate = new Date(Date.now() + (response.expires_in - 300) * 1000);
 
 		// Parse the Token
 		const parsedToken: Token = {
-			tokenType: this.token?.tokenType || response.token_type,
-			refreshToken: this.token?.refreshToken || response.refresh_token,
-			refreshTokenExpiryDate: refreshTokenExpiryDate,
+			tokenType: response.token_type,
+			refreshToken: response.refresh_token,
+			refreshTokenExpiryDate: newRefreshTokenExpiryDate,
 			accessToken: response.access_token,
 			accessTokenExpiryDate: accessTokenExpiryDate,
 			realmId: realmId,


### PR DESCRIPTION
Used New Refresh Tokens instead of existing token when refreshing access token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Bumped the release version to 0.3.2.
- **Bug Fixes**
	- Enhanced authentication by refining token expiry calculations.
	- Improved refresh token handling to ensure uninterrupted, secure sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->