### PR TITLE
feat(auth): implement event emitter for token refresh/revoke events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+# [0.4.1] - 2025-03-18
+
+### Features
+
+- Added event emitter for token refresh and revoke events
+- Implemented `onRefresh` and `onRevoke` callback registration methods
+
+### Documentation
+
+- Updated authentication section with event listener examples
+- Added API reference entries for new event methods
+
+---
+
 # [0.4.0] - 2025-02-21
 
 ### Features
@@ -32,6 +46,8 @@
 - Improved error handling in pagination checks
 - Enhanced type safety for numeric range constraints
 
+---
+
 ## [0.3.2] - 2025-03-17
 
 ### Bug Fixes
@@ -40,6 +56,8 @@
   token is always up to date
 - Used newly given Refresh Token instead of existing Refresh Token after refreshing the access token to ensure the refresh token is always
   up to date
+
+---
 
 ## [0.3.1] - 2025-03-16
 
@@ -51,6 +69,8 @@
 ### Code Quality
 
 - Refactored token parsing logic to handle edge cases more reliably
+
+---
 
 ## [0.3.0] - 2025-03-15
 
@@ -83,6 +103,8 @@
 - Added biome.json configuration for code formatting
 - Updated test helpers to support estimate data mocking
 - Improved token serialization/deserialization examples
+
+---
 
 ## [0.2.0] - 2025-02-11
 
@@ -118,17 +140,23 @@
 - Standardized query builder usage across all API methods
 - Removed deprecated URL parameter handling from QueryBuilder
 
+---
+
 ## [0.1.4] - 2025-02-10
 
 ### Features
 
 - Added the ability to generate the Auth URL with a custom state
 
+---
+
 ## [0.1.3] - 2025-02-10
 
 ### Infrastructure
 
 - Updated the Build Flow to include tsc-alias for TypeScript alias resolution (emit js extension in imports)
+
+---
 
 ## [0.1.2] - 2025-02-10
 
@@ -169,11 +197,15 @@
 - Improved type definitions with DeepKeys utility type
 - Enhanced error messages and inline documentation
 
+---
+
 ## [0.1.1] - 2025-02-08
 
 ### QOL
 
 - Updated the Workflow file used to publish the package to NPM
+
+---
 
 ## [0.1.0] - 2025-02-08
 
@@ -205,6 +237,8 @@
 - Included code examples for token revocation flow
 - Documented secret key requirements and best practices
 
+---
+
 ## [0.0.4] - 2025-02-07
 
 ### Features
@@ -221,7 +255,9 @@
 - Initial test framework configuration
 - Documentation scaffolding
 
-## **v0.0.3** | 2025-02-07
+---
+
+## [0.0.3] | 2025-02-07
 
 ### Features
 
@@ -229,7 +265,7 @@
 
 ---
 
-## **v0.0.2** | 2025-02-07
+## [0.0.2] | 2025-02-07
 
 ### Features
 
@@ -246,7 +282,7 @@
 
 ---
 
-## **v0.0.1** | 2025-02-06
+## [0.0.1] | 2025-02-06
 
 ### Initial Release
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ async function revokeToken() {
 }
 ```
 
+### Event Listeners
+
+```typescript
+// Subscribe to token refresh events
+authProvider.onRefresh((newToken) => {
+  console.log('Token refreshed:', newToken.accessToken);
+});
+
+// Subscribe to token revocation events
+authProvider.onRevoke((revokedToken) => {
+  console.log('Token revoked:', revokedToken.accessToken);
+});
+```
+
 ### Secure Token Serialization
 
 ```typescript
@@ -211,6 +225,8 @@ const recentEstimates = await apiClient.estimates.getUpdatedEstimates(new Date('
 - `getToken()` - Get the current token (if expired, it will be refreshed)
 - `refresh()` - Refreshes the stored access token
 - `revoke()` - Revokes the stored access token
+- `onRefresh(callback)` - Register callback for token refresh events
+- `onRevoke(callback)` - Register callback for token revocation events
 
 ### Invoices API
 

--- a/__live-tests__/auth-provider.test.ts
+++ b/__live-tests__/auth-provider.test.ts
@@ -1,5 +1,5 @@
 // Imports
-import { AuthProvider, AuthScopes } from '../src/app';
+import { AuthProvider, AuthScopes, type Token } from '../src/app';
 import { describe, expect, test } from 'bun:test';
 
 // Describe the Auth Provider
@@ -44,6 +44,27 @@ describe('Live Auth Provider', async () => {
 		// Test the Token
 		expect(newToken).toBeDefined();
 		expect(newToken.accessToken).not.toBe(originalToken.accessToken);
+	});
+
+	// Test token refresh event
+	test('should emit refresh event', async () => {
+		// Get the original Token
+		const originalToken = await authProvider.getToken();
+
+		// Setup the refreshed token
+		let refreshedToken: Token;
+
+		// Setup the Event Listener
+		authProvider.onRefresh((token) => {
+			refreshedToken = token;
+		});
+
+		// Refresh the Token
+		await authProvider.refresh();
+
+		// Test the Token
+		expect(refreshedToken).toBeDefined();
+		expect(refreshedToken.accessToken).not.toBe(originalToken.accessToken);
 	});
 
 	// Test token serialization

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "quickbooks-api",
 	"author": "JackNytely <jacknytely@gmail.com>",
 	"license": "MIT",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "A modular TypeScript SDK for seamless integration with Intuit QuickBooks APIs. Provides robust authentication handling and future-ready foundation for accounting, payments, and commerce operations.",
 	"type": "module",
 	"main": "dist/app.js",

--- a/src/packages/auth/auth-provider.ts
+++ b/src/packages/auth/auth-provider.ts
@@ -382,7 +382,7 @@ export class AuthProvider {
 	 * Adds a callback to be called when the token is refreshed
 	 * @param callback The callback to call when the token is refreshed
 	 */
-	public async onRefresh(callback: (refreshedToken: Token) => void): Promise<void> {
+	public onRefresh(callback: (refreshedToken: Token) => void): void {
 		// Add the callback to the list of callbacks
 		this.eventEmitter.on('refresh', callback);
 	}
@@ -391,7 +391,7 @@ export class AuthProvider {
 	 * Adds a callback to be called when the token is revoked
 	 * @param callback The callback to call when the token is revoked
 	 */
-	public async onRevoke(callback: (revokedToken: Token) => void): Promise<void> {
+	public onRevoke(callback: (revokedToken: Token) => void): void {
 		// Add the callback to the list of callbacks
 		this.eventEmitter.on('revoke', callback);
 	}


### PR DESCRIPTION
- Add EventEmitter instance to AuthProvider class
- Emit 'refresh' event after successful token refresh
- Emit 'revoke' event before clearing token
- Add onRefresh/onRevoke subscription methods
- Update documentation with event listener examples
- Add changelog entry for v0.4.1 features
- Added Tests to ensure the Refresh Events correctly execute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added event-driven token management with support for refresh and revocation events.
  - Introduced callback registration methods to enable custom handling when tokens are refreshed or revoked.
- **Documentation**
  - Updated API documentation and examples to illustrate the new event listener functionality.
- **Tests**
  - Included tests to verify the proper emission of token refresh events.
- **Chores**
  - Bumped the package version to reflect these improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->