### PR TITLE
feat(company-info): add endpoint to retrieve company info

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ foundation for accounting, payments, and commerce operations.
   - Customers
   - Payments
   - Accounts
+  - CompanyInfo
   - Preferences
   - Credit Memos
 - **Type-Safe API:** Full TypeScript declarations for all requests and responses.

--- a/__live-tests__/company-info-api.test.ts
+++ b/__live-tests__/company-info-api.test.ts
@@ -1,0 +1,119 @@
+// Imports
+import { AuthProvider, Environment, ApiClient, AuthScopes, type SearchOptions, CompanyInfo } from '../src/app';
+import { describe, expect, test } from 'bun:test';
+
+// Describe the Company Info API
+describe('Live API: Company Info', async () => {
+    // Initialize the Auth Provider
+    const authProvider = new AuthProvider(process.env.QB_CLIENT_ID!, process.env.QB_CLIENT_SECRET!, process.env.REDIRECT_URI!, [
+        AuthScopes.Accounting,
+    ]);
+
+    // Deserialize the Token
+    await authProvider.deserializeToken(process.env.SERIALIZED_TOKEN!, process.env.SECRET_KEY!);
+
+    // Setup the API Client
+    const apiClient = new ApiClient(authProvider, Environment.Sandbox);
+
+    // Test retrieving company info
+    test('should retrieve company info', async () => {
+        // Get company info
+        const companyInfo = await apiClient.companyInfo.getCompanyInfo();
+
+        // Test the Company Info
+        expect(companyInfo).toBeDefined();
+        expect(companyInfo.Id).toBeDefined();
+        expect(companyInfo.CompanyName).toBeDefined();
+        expect(companyInfo.LegalName).toBeDefined();
+    });
+
+    // Test retrieving company info with search options
+    test('should retrieve company info with search options', async () => {
+        // Setup the Search Options
+        const searchOptions: SearchOptions<CompanyInfo> = { maxResults: 1 };
+
+        // Get company info with search options
+        const companyInfo = await apiClient.companyInfo.getCompanyInfo(searchOptions);
+
+        // Test the Company Info
+        expect(companyInfo).toBeDefined();
+        expect(companyInfo.Id).toBeDefined();
+        expect(companyInfo.CompanyName).toBeDefined();
+        expect(companyInfo.LegalName).toBeDefined();
+    });
+
+    // Test retrieving company info with raw query
+    test('should retrieve company info with raw query', async () => {
+        // Get company info with raw query
+        const companyInfo = await apiClient.companyInfo.rawCompanyInfoQuery('select * from companyinfo');
+
+        // Test the Company Info
+        expect(companyInfo).toBeDefined();
+        expect(companyInfo.Id).toBeDefined();
+        expect(companyInfo.CompanyName).toBeDefined();
+        expect(companyInfo.LegalName).toBeDefined();
+    });
+
+    // Test error handling for invalid raw query
+    test('should throw error for invalid raw query', async () => {
+        // Assert the Error
+        expect(apiClient.companyInfo.rawCompanyInfoQuery('select * from invalid')).rejects.toThrow();
+    });
+
+    // Test company info contains expected fields
+    test('should contain expected fields', async () => {
+        // Get company info
+        const companyInfo = await apiClient.companyInfo.getCompanyInfo();
+
+        // Test the Company Info has expected fields
+        expect(companyInfo).toHaveProperty('Id');
+        expect(companyInfo).toHaveProperty('CompanyName');
+        expect(companyInfo).toHaveProperty('LegalName');
+        expect(companyInfo).toHaveProperty('CompanyAddr');
+        expect(companyInfo).toHaveProperty('Country');
+        expect(companyInfo).toHaveProperty('Email');
+        expect(companyInfo).toHaveProperty('WebAddr');
+        expect(companyInfo).toHaveProperty('SupportedLanguages');
+        expect(companyInfo).toHaveProperty('FiscalYearStartMonth');
+    });
+
+    // Test company info address structure
+    test('should have valid address structure', async () => {
+        // Get company info
+        const companyInfo = await apiClient.companyInfo.getCompanyInfo();
+
+        // Test the Company Address
+        expect(companyInfo.CompanyAddr).toBeDefined();
+        expect(companyInfo.CompanyAddr).toHaveProperty('Id');
+        expect(companyInfo.CompanyAddr).toHaveProperty('Line1');
+        expect(companyInfo.CompanyAddr).toHaveProperty('City');
+        expect(companyInfo.CompanyAddr).toHaveProperty('PostalCode');
+    });
+
+    // Test company info metadata
+    test('should have valid metadata', async () => {
+        // Get company info
+        const companyInfo = await apiClient.companyInfo.getCompanyInfo();
+
+        // Test the Metadata
+        expect(companyInfo.MetaData).toBeDefined();
+        expect(companyInfo.MetaData).toHaveProperty('CreateTime');
+        expect(companyInfo.MetaData).toHaveProperty('LastUpdatedTime');
+    });
+
+    // Test company info name values
+    test('should have name values', async () => {
+        // Get company info
+        const companyInfo = await apiClient.companyInfo.getCompanyInfo();
+
+        // Test the Name Values
+        expect(companyInfo.NameValue).toBeDefined();
+        expect(companyInfo.NameValue).toBeInstanceOf(Array);
+        expect(companyInfo.NameValue.length).toBeGreaterThan(0);
+
+        // Test the first Name Value
+        const firstNameValue = companyInfo.NameValue[0];
+        expect(firstNameValue).toHaveProperty('Name');
+        expect(firstNameValue).toHaveProperty('Value');
+    });
+}); 

--- a/__tests__/__mocks__/company-info-data.ts
+++ b/__tests__/__mocks__/company-info-data.ts
@@ -1,0 +1,96 @@
+import { CompanyInfo } from "../../src/app";
+
+export const mockCompanyInfoData: CompanyInfo = {
+    SyncToken: "4",
+    domain: "QBO",
+    LegalAddr: {
+        City: "Mountain View",
+        Country: "US",
+        Line1: "2500 Garcia Ave",
+        PostalCode: "94043",
+        CountrySubDivisionCode: "CA",
+        Id: "1"
+    },
+    SupportedLanguages: "en",
+    CompanyName: "Larry's Bakery",
+    Country: "US",
+    CompanyAddr: {
+        City: "Mountain View",
+        Country: "US",
+        Line1: "2500 Garcia Ave",
+        PostalCode: "94043",
+        CountrySubDivisionCode: "CA",
+        Id: "1"
+    },
+    sparse: false,
+    Id: "1",
+    WebAddr: {},
+    FiscalYearStartMonth: "January",
+    CustomerCommunicationAddr: {
+        City: "Mountain View",
+        Country: "US",
+        Line1: "2500 Garcia Ave",
+        PostalCode: "94043",
+        CountrySubDivisionCode: "CA",
+        Id: "1"
+    },
+    PrimaryPhone: {
+        FreeFormNumber: "(650)944-4444"
+    },
+    LegalName: "Larry's Bakery",
+    CompanyStartDate: "2015-06-05",
+    EmployerId: "123456789",
+    Email: {
+        Address: "donotreply@intuit.com"
+    },
+    NameValue: [
+        {
+            Name: "NeoEnabled",
+            Value: "true"
+        },
+        {
+            Name: "IndustryType",
+            Value: "Bread and Bakery Product Manufacturing"
+        },
+        {
+            Name: "IndustryCode",
+            Value: "31181"
+        },
+        {
+            Name: "SubscriptionStatus",
+            Value: "PAID"
+        },
+        {
+            Name: "OfferingSku",
+            Value: "QuickBooks Online Plus"
+        },
+        {
+            Name: "PayrollFeature",
+            Value: "true"
+        },
+        {
+            Name: "AccountantFeature",
+            Value: "false"
+        },
+        {
+            Name: "IsQbdtMigrated",
+            Value: "true"
+        },
+        {
+            Name: "MigrationDate",
+            Value: "2024-09-14T01:47:34-07:00"
+        },
+        {
+            Name: "QBOIndustryType",
+            Value: "Manufacturing Businesses"
+        },
+        {
+            Name: "AssignedTime",
+            Value: "2024-09-14T01:47:34-07:00"
+        }
+    ],
+    MetaData: {
+        CreateTime: "2015-06-05T13:55:54-07:00",
+        LastUpdatedTime: "2015-07-06T08:51:50-07:00"
+    }
+}

--- a/__tests__/company-info.test.ts
+++ b/__tests__/company-info.test.ts
@@ -1,0 +1,178 @@
+import { ApiClient } from '../src/app';
+import { AuthProvider, Environment, AuthScopes, type CompanyInfoQueryResponse } from '../src/app';
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { mockFetch, mockTokenData } from './helpers';
+import { mockCompanyInfoData } from './__mocks__/company-info-data';
+
+// Mock configuration
+const TEST_CONFIG = {
+	clientId: 'test_client_id',
+	clientSecret: 'test_client_secret',
+	redirectUri: 'http://localhost:3000/auth-code',
+	scopes: [AuthScopes.Accounting],
+};
+
+// Describe the Company Info API
+describe('Company Info API', () => {
+	// Declare the API Client
+	let apiClient: ApiClient;
+
+	// Declare the Global Fetch
+	let globalFetch: typeof fetch;
+
+	// Before Each
+	beforeEach(async () => {
+		// Set the Global Fetch
+		globalFetch = global.fetch;
+
+		// Create the Auth Provider
+		const authProvider = new AuthProvider(TEST_CONFIG.clientId, TEST_CONFIG.clientSecret, TEST_CONFIG.redirectUri, TEST_CONFIG.scopes);
+
+		// Set the Token for the Auth Provider
+		await authProvider.setToken(mockTokenData);
+
+		// Create the API Client
+		apiClient = new ApiClient(authProvider, Environment.Sandbox);
+	});
+
+	// After Each
+	afterEach(() => {
+		// Set the Global Fetch
+		global.fetch = globalFetch;
+	});
+
+	// Describe the getCompanyInfo Method
+	describe('getCompanyInfo', () => {
+		// After Each
+		afterEach(() => {
+			// Set the Global Fetch
+			global.fetch = globalFetch;
+		});
+
+		// Test fetching company info
+		it('should fetch company info', async () => {
+			// Setup the Company Info Query Response
+			const companyInfoQueryResponse = {
+				QueryResponse: {
+					CompanyInfo: [mockCompanyInfoData],
+					maxResults: 1,
+					startPosition: 1,
+					totalCount: 1,
+				},
+			};
+
+			// Mock the Fetch with proper QueryResponse structure
+			global.fetch = mockFetch(JSON.stringify(companyInfoQueryResponse));
+
+			// Get the Company Info
+			const companyInfo = await apiClient.companyInfo.getCompanyInfo();
+
+			// Assert the Company Info
+			expect(companyInfo).toBeObject();
+			expect(companyInfo.Id).toBe(mockCompanyInfoData.Id);
+			expect(companyInfo.CompanyName).toBe(mockCompanyInfoData.CompanyName);
+			expect(companyInfo.LegalName).toBe(mockCompanyInfoData.LegalName);
+			expect(companyInfo.Email.Address).toBe(mockCompanyInfoData.Email.Address);
+			expect(companyInfo.PrimaryPhone.FreeFormNumber).toBe(mockCompanyInfoData.PrimaryPhone.FreeFormNumber);
+		});
+
+		// Test handling search options
+		it('should handle search options', async () => {
+			// Setup the Company Info Query Response
+			const companyInfoQueryResponse = {
+				QueryResponse: {
+					CompanyInfo: [mockCompanyInfoData],
+					maxResults: 1,
+					startPosition: 1,
+					totalCount: 1,
+				},
+			};
+
+			// Mock the Fetch with proper QueryResponse structure
+			global.fetch = mockFetch(JSON.stringify(companyInfoQueryResponse));
+
+			// Get the Company Info with search options
+			const companyInfo = await apiClient.companyInfo.getCompanyInfo({
+				maxResults: 1,
+				page: 1,
+			});
+
+			// Assert the Company Info
+			expect(companyInfo).toBeObject();
+			expect(companyInfo.Id).toBe(mockCompanyInfoData.Id);
+		});
+
+		// Test error handling when no company info is found
+		it('should throw error when no company info is found', async () => {
+			// Setup the Company Info Query Response with empty CompanyInfo array
+			const companyInfoQueryResponse = {
+				QueryResponse: {
+					CompanyInfo: [],
+					maxResults: 0,
+					startPosition: 1,
+					totalCount: 0,
+				},
+			};
+
+			// Mock the Fetch with proper QueryResponse structure
+			global.fetch = mockFetch(JSON.stringify(companyInfoQueryResponse));
+
+			// Assert the Error
+			await expect(apiClient.companyInfo.getCompanyInfo()).rejects.toThrow('No Company Info found');
+		});
+
+		// Test error handling for invalid response
+		it('should throw error for invalid response', async () => {
+			// Mock empty response with 400 status
+			global.fetch = mockFetch(
+				JSON.stringify({
+					fault: { error: [{ message: 'Invalid Response' }] },
+				}),
+				400,
+			);
+
+			// Assert the Error
+			await expect(apiClient.companyInfo.getCompanyInfo()).rejects.toThrow('Failed to run request');
+		});
+	});
+
+	// Describe the rawCompanyInfoQuery Method
+	describe('rawCompanyInfoQuery', () => {
+		it('should execute raw company info query', async () => {
+			// Setup the Company Info Query Response
+			const companyInfoQueryResponse = {
+				QueryResponse: {
+					CompanyInfo: [mockCompanyInfoData],
+					maxResults: 1,
+					startPosition: 1,
+					totalCount: 1,
+				},
+			};
+
+			// Mock the Fetch with proper QueryResponse structure
+			global.fetch = mockFetch(JSON.stringify(companyInfoQueryResponse));
+
+			// Execute Raw Query
+			const companyInfo = await apiClient.companyInfo.rawCompanyInfoQuery('select * from companyinfo');
+
+			// Assert the Company Info
+			expect(companyInfo).toBeObject();
+			expect(companyInfo.Id).toBe(mockCompanyInfoData.Id);
+			expect(companyInfo.CompanyName).toBe(mockCompanyInfoData.CompanyName);
+		});
+
+		// Test error handling for raw query
+		it('should throw error for invalid raw query', async () => {
+			// Mock empty response with 400 status
+			global.fetch = mockFetch(
+				JSON.stringify({
+					fault: { error: [{ message: 'Invalid Query' }] },
+				}),
+				400,
+			);
+
+			// Assert the Error
+			await expect(apiClient.companyInfo.rawCompanyInfoQuery('invalid query')).rejects.toThrow('Failed to run request');
+		});
+	});
+}); 

--- a/src/packages/api/api-client.ts
+++ b/src/packages/api/api-client.ts
@@ -8,6 +8,7 @@ import { PaymentAPI } from './payment/payment-api';
 import { AccountAPI } from './account/account-api';
 import { PreferenceAPI } from './preferences/preference-api';
 import { CreditMemoAPI } from './credit-memo/credit-memo-api';
+import { CompanyInfoAPI } from './company-info/company-info-api';
 
 /**
  * API Client
@@ -48,6 +49,11 @@ export class ApiClient {
 	public preferences: PreferenceAPI;
 
 	/**
+	 * Company Info API
+	 */
+	public companyInfo: CompanyInfoAPI;
+
+	/**
 	 * Automatically check for a next page (This creates an extra query to the API to check if there is a next page)
 	 */
 	public autoCheckNextPage: boolean = true;
@@ -66,6 +72,7 @@ export class ApiClient {
 		this.payments = new PaymentAPI(this);
 		this.preferences = new PreferenceAPI(this);
 		this.creditMemos = new CreditMemoAPI(this);
+		this.companyInfo = new CompanyInfoAPI(this);
 	}
 
 	/**

--- a/src/packages/api/company-info/company-info-api.ts
+++ b/src/packages/api/company-info/company-info-api.ts
@@ -1,0 +1,76 @@
+// Imports
+import { ApiClient } from '../api-client';
+import { Environment, Query, type CompanyInfo, type CompanyInfoQueryResponse } from '../../../types/types';
+import { Endpoints } from '../../../types/enums/endpoints';
+import { CompanyInfoQueryBuilder } from './company-info-query-builder';
+
+// Import the Services
+import { getCompanyInfo } from './services/get-company-info';
+import { rawCompanyInfoQuery } from './services/raw-company-info-query';
+
+/**
+ * Company Info API
+ */
+export class CompanyInfoAPI {
+	// The List of Company Info Services
+	public readonly getCompanyInfo = getCompanyInfo.bind(this);
+	public readonly rawCompanyInfoQuery = rawCompanyInfoQuery.bind(this);
+
+	/**
+	 * Constructor
+	 * @param apiClient - The API Client
+	 */
+	constructor(protected readonly apiClient: ApiClient) {}
+
+	/**
+	 * Get the Company Endpoint
+	 * @returns The Company Endpoint with the attached token realmId
+	 */
+	protected async getCompanyEndpoint() {
+		// Get the Base Endpoint
+		const baseEndpoint =
+			this.apiClient.environment === Environment.Production ? Endpoints.ProductionCompanyApi : Endpoints.SandboxCompanyApi;
+
+		// Get the Token
+		const token = await this.apiClient.authProvider.getToken();
+
+		// Return the Company Endpoint
+		return `${baseEndpoint}/${token.realmId}`;
+	}
+
+	/**
+	 * Format the Response
+	 * @param response - The Response
+	 * @returns The Company Info
+	 */
+	protected formatResponse(response: any): CompanyInfo {
+		// Check if the Response is Invalid
+		if (!response?.QueryResponse) throw new Error('Invalid Response');
+
+		// Check if the CompanyInfo is Not set
+		if (!response.QueryResponse.CompanyInfo || response.QueryResponse.CompanyInfo.length === 0) {
+			throw new Error('No Company Info found');
+		}
+
+		// Get the Company Info
+		const queryResponse = response.QueryResponse as CompanyInfoQueryResponse;
+
+		// Return the first Company Info (there should only be one)
+		return queryResponse.CompanyInfo[0];
+	}
+
+	/**
+	 * Get the Query Builder
+	 * @returns The Query Builder
+	 */
+	public async getQueryBuilder(): Promise<CompanyInfoQueryBuilder> {
+		// Get the Company Endpoint
+		const companyEndpoint = await this.getCompanyEndpoint();
+
+		// Setup the New Query Builder
+		const queryBuilder = new CompanyInfoQueryBuilder(companyEndpoint, Query.CompanyInfo);
+
+		// Return the Query Builder
+		return queryBuilder;
+	}
+} 

--- a/src/packages/api/company-info/company-info-query-builder.ts
+++ b/src/packages/api/company-info/company-info-query-builder.ts
@@ -1,0 +1,17 @@
+// Imports
+import type { CompanyInfo, Query } from '../../../types/types';
+import { BaseQueryBuilder } from '../common/base-query-builder';
+
+/**
+ * The Company Info Query Builder
+ */
+export class CompanyInfoQueryBuilder extends BaseQueryBuilder<CompanyInfo> {
+	/**
+	 * Constructor
+	 * @param endpoint - The Endpoint
+	 * @param baseQuery - The Base Query
+	 */
+	constructor(endpoint: string, baseQuery: Query) {
+		super(endpoint, baseQuery);
+	}
+} 

--- a/src/packages/api/company-info/services/get-company-info.ts
+++ b/src/packages/api/company-info/services/get-company-info.ts
@@ -1,0 +1,29 @@
+// Imports
+import type { CompanyInfo, SearchOptions } from '../../../../types/types';
+import { CompanyInfoAPI } from '../company-info-api';
+
+/**
+ * Get Company Info
+ * @param this - The Company Info API
+ * @param options - The Search Options
+ * @returns The Company Info
+ */
+export async function getCompanyInfo(this: CompanyInfoAPI, options: SearchOptions = {}): Promise<CompanyInfo> {
+	// Get the Query Builder
+	const queryBuilder = await this.getQueryBuilder();
+
+	// Setup the Search Options (if provided)
+	if (options) queryBuilder.setSearchOptions(options);
+
+	// Setup the URL
+	const url = queryBuilder.build();
+
+	// Get the Company Info
+	const response = await this.apiClient.runRequest(url, { method: 'GET' });
+
+	// Format the Response
+	const companyInfo = this.formatResponse(response);
+
+	// Return the Company Info
+	return companyInfo;
+} 

--- a/src/packages/api/company-info/services/raw-company-info-query.ts
+++ b/src/packages/api/company-info/services/raw-company-info-query.ts
@@ -1,0 +1,26 @@
+// Imports
+import type { CompanyInfo } from '../../../../types/types';
+import { CompanyInfoAPI } from '../company-info-api';
+
+/**
+ * Raw Company Info Query
+ * @param this - The Company Info API
+ * @param query - The Raw Query
+ * @returns The Company Info
+ */
+export async function rawCompanyInfoQuery(this: CompanyInfoAPI, query: string): Promise<CompanyInfo> {
+	// Get the Company Endpoint
+	const companyEndpoint = await this.getCompanyEndpoint();
+
+	// Setup the URL
+	const url = `${companyEndpoint}/query?query=${encodeURIComponent(query)}`;
+
+	// Get the Company Info
+	const response = await this.apiClient.runRequest(url, { method: 'GET' });
+
+	// Format the Response
+	const companyInfo = this.formatResponse(response);
+
+	// Return the Company Info
+	return companyInfo;
+} 

--- a/src/types/enums/query.ts
+++ b/src/types/enums/query.ts
@@ -9,4 +9,5 @@ export enum Query {
 	CreditMemo = 'select * from creditmemo',
 	Preferences = 'select * from Preferences',
 	Account = 'select * from account',
+	CompanyInfo = 'select * from companyinfo',
 }

--- a/src/types/interfaces/company.ts
+++ b/src/types/interfaces/company.ts
@@ -1,0 +1,81 @@
+/**
+ * The Company Info Object
+ */
+export interface CompanyInfo {
+    SyncToken: string;
+    domain: string;
+    LegalAddr: PhysicalAddress;
+    SupportedLanguages: string;
+    CompanyName: string;
+    Country: string;
+    CompanyAddr: PhysicalAddress;
+    sparse: boolean;
+    Id: string;
+    WebAddr: WebSiteAddress;
+    FiscalYearStartMonth: string;
+    CustomerCommunicationAddr: PhysicalAddress;
+    PrimaryPhone: PhoneNumber;
+    LegalName: string;
+    CompanyStartDate: string;
+    EmployerId: string;
+    Email: EmailAddress;
+    NameValue: NameValuePair[];
+    MetaData: ModificationMetaData;
+}
+
+/**################### Supporting Interfaces ###################*/
+/**
+ * The Name Value Pair Type
+ */
+interface NameValuePair {
+    Name: string;
+    Value: string;
+}
+
+/**
+ * The Web Site Address Type
+ */
+interface WebSiteAddress {
+    URI?: string;
+}
+
+/**
+ * The Physical Address Type
+ */
+interface PhysicalAddress {
+    Id?: string;
+    Line1?: string;
+    Line2?: string;
+    Line3?: string;
+    Line4?: string;
+    Line5?: string;
+    City?: string;
+    Country?: string;
+    CountrySubDivisionCode?: string;
+    PostalCode?: string;
+    Lat?: string;
+    Long?: string;
+}
+
+/**
+ * The Email Address Type
+ */
+interface EmailAddress {
+    Address?: string;
+}
+
+/**
+ * The Modification Meta Data Type
+ */
+interface ModificationMetaData {
+    CreateTime?: string;
+    LastUpdatedTime?: string;
+    LastUpdatedBy?: string;
+}
+
+/**
+ * The Phone Number Type
+ */
+interface PhoneNumber {
+    FreeFormNumber: string;
+}

--- a/src/types/interfaces/query-response.ts
+++ b/src/types/interfaces/query-response.ts
@@ -1,5 +1,5 @@
 // Imports
-import type { Estimate, Customer, Invoice, Payment, Account, CreditMemo, Preferences } from '../types';
+import type { Estimate, Customer, Invoice, Payment, Account, CreditMemo, Preferences, CompanyInfo } from '../types';
 
 /**
  * The Invoice Query Response
@@ -40,6 +40,13 @@ export interface PaymentQueryResponse extends QueryResponse {
  */
 export interface AccountQueryResponse extends QueryResponse {
 	Account: Array<Account>;
+}
+
+/**
+ * The CompanyInfo Query Response
+ */
+export interface CompanyInfoQueryResponse extends QueryResponse {
+	CompanyInfo: Array<CompanyInfo>;
 }
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -24,6 +24,7 @@ export type {
 	PreferenceOptions,
 } from './interfaces/options';
 export type { Account } from './interfaces/account';
+export type { CompanyInfo } from './interfaces/company';
 export type { CreditMemo } from './interfaces/credit-memo';
 export type { Preferences } from './interfaces/preferences';
 export type {
@@ -35,6 +36,7 @@ export type {
 	AccountQueryResponse,
 	PreferenceQueryResponse,
 	CreditMemoQueryResponse,
+	CompanyInfoQueryResponse,
 } from './interfaces/query-response';
 export type { SearchOptions } from './interfaces/search-options';
 export type { SearchResponse } from './interfaces/search-response';


### PR DESCRIPTION
- Company Info - api/query builder/services 
- Live Tests for company info
- Mock Tests for company info
- Types: company info / company info response / enum

- bug(raw-query): cannot query individual items off company table, cant do it in my playground either so maybe its just that way