### PR TITLE
Use company selection OAuth endpoint and bump jose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.11.1] - 2026-03-06
+
+### Changed
+
+- **OAuth User Auth endpoint:** Updated `UserAuth` in `Endpoints` from `/connect/oauth2` to `/connect/oauth2/companyselection` so the
+  authorization URL uses Intuit’s company selection flow
+- **Dependencies:** Bumped `jose` from `^6.1.3` to `^6.2.0`
+
+### Tests
+
+- Updated auth-provider test to assert the generated auth URL uses the new company selection path
+
 ## [0.11.0] - 2025-12-04
 
 ### Features

--- a/__tests__/auth-provider.test.ts
+++ b/__tests__/auth-provider.test.ts
@@ -41,7 +41,7 @@ describe('AuthProvider', () => {
 			const url = authProvider.generateAuthUrl();
 
 			// Assert the URL
-			expect(url.toString()).toStartWith('https://appcenter.intuit.com/connect/oauth2');
+			expect(url.toString()).toStartWith('https://appcenter.intuit.com/connect/oauth2/companyselection');
 			expect(url.searchParams.get('client_id')).toBe(TEST_CONFIG.clientId);
 			expect(url.searchParams.get('scope')).toBe(TEST_CONFIG.scopes.join(' '));
 			expect(url.searchParams.get('redirect_uri')).toBe(TEST_CONFIG.redirectUri);

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "quickbooks-api",
       "dependencies": {
         "class-transformer": "^0.5.1",
-        "jose": "^6.1.3",
+        "jose": "^6.2.0",
         "tiny-emitter": "^2.1.0",
       },
       "devDependencies": {
@@ -162,7 +162,7 @@
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
-    "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
+    "jose": ["jose@6.2.0", "", {}, "sha512-xsfE1TcSCbUdo6U07tR0mvhg0flGxU8tPLbF03mirl2ukGQENhUg4ubGYQnhVH0b5stLlPM+WOqDkEl1R1y5sQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "quickbooks-api",
 	"author": "JackNytely <jacknytely@gmail.com>",
 	"license": "MIT",
-	"version": "0.11.0",
+	"version": "0.11.1",
 	"description": "A modular TypeScript SDK for seamless integration with Intuit QuickBooks APIs. Provides robust authentication handling and future-ready foundation for accounting, payments, and commerce operations.",
 	"type": "module",
 	"main": "dist/app.js",
@@ -27,7 +27,7 @@
 	},
 	"dependencies": {
 		"class-transformer": "^0.5.1",
-		"jose": "^6.1.3",
+		"jose": "^6.2.0",
 		"tiny-emitter": "^2.1.0"
 	},
 	"devDependencies": {

--- a/src/types/enums/endpoints.ts
+++ b/src/types/enums/endpoints.ts
@@ -6,7 +6,7 @@ import { APIUrls } from './api-urls';
  */
 export enum Endpoints {
 	// Auth Related Endpoints
-	UserAuth = `${APIUrls.UserAuth}/connect/oauth2`,
+	UserAuth = `${APIUrls.UserAuth}/connect/oauth2/companyselection`,
 	TokenBearer = `${APIUrls.OAuth2}/tokens/bearer`,
 	TokenRevoke = `${APIUrls.OAuthDeveloper}/tokens/revoke`,
 


### PR DESCRIPTION
Updates the OAuth authorization URL to Intuit’s company selection flow and bumps the `jose` dependency.

## Changes
- **OAuth endpoint:** `UserAuth` in `src/types/enums/endpoints.ts` is now  
  `https://appcenter.intuit.com/connect/oauth2/companyselection` instead of  
  `https://appcenter.intuit.com/connect/oauth2`, so users are sent through the company selection step during sign-in.
- **Dependencies:** `jose` upgraded from `^6.1.3` to `^6.2.0`.
- **Tests:** Auth-provider test updated to expect the new auth URL path.

## Impact
- Only `generateAuthUrl()` uses `Endpoints.UserAuth`; token exchange, refresh, and revoke are unchanged.
- No breaking API changes; callers still use `generateAuthUrl()` the same way.

## Version
- Bump: `0.11.0` → `0.11.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated OAuth authentication endpoint to route through company selection flow for improved user experience
  * Upgraded jose dependency to version 6.2.0

* **Tests**
  * Updated test assertions to validate new authentication endpoint behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->