### PR TITLE
feat: add RecurringTransaction entity support

### DIFF
--- a/__tests__/__mocks__/recurring-transaction-data.ts
+++ b/__tests__/__mocks__/recurring-transaction-data.ts
@@ -1,0 +1,130 @@
+import type { RecurringTransaction } from '../../src/app';
+
+export const mockRecurringTransactionData: Array<RecurringTransaction> = [
+	{
+		Id: 'RT-001',
+		SyncToken: '0',
+		MetaData: {
+			CreateTime: '2024-01-15T10:00:00Z',
+			LastUpdatedTime: '2024-01-15T10:30:00Z',
+		},
+		RecurringInfo: {
+			Name: 'Monthly HOA Invoice - Unit 2A',
+			RecurType: 'Automated',
+			Active: true,
+			ScheduleInfo: {
+				IntervalType: 'Monthly',
+				NumInterval: 1,
+				DayOfMonth: 1,
+				StartDate: '2026-03-01',
+				NextDate: '2026-03-01',
+				MaxOccurrences: 0,
+				DaysBefore: 0,
+			},
+		},
+		Invoice: {
+			CustomerRef: { value: 'QBO-CUST-001', name: 'Jane Smith' },
+			Line: [
+				{
+					Amount: 500.0,
+					DetailType: 'SalesItemLineDetail',
+					Description: 'Monthly Common Charge',
+					SalesItemLineDetail: {
+						ItemRef: { value: '1', name: 'HOA Common Charge' },
+						UnitPrice: 500.0,
+						Qty: 1,
+					},
+				},
+			],
+			DueDate: '2026-03-01',
+			BillEmail: { Address: 'jane.smith@test.com' },
+		},
+	},
+	{
+		Id: 'RT-002',
+		SyncToken: '1',
+		MetaData: {
+			CreateTime: '2024-01-15T10:05:00Z',
+			LastUpdatedTime: '2024-01-15T10:35:00Z',
+		},
+		RecurringInfo: {
+			Name: 'Monthly HOA Invoice - Unit 3B',
+			RecurType: 'Automated',
+			Active: true,
+			ScheduleInfo: {
+				IntervalType: 'Monthly',
+				NumInterval: 1,
+				DayOfMonth: 1,
+				StartDate: '2026-03-01',
+				NextDate: '2026-03-01',
+				MaxOccurrences: 0,
+				DaysBefore: 0,
+			},
+		},
+		Invoice: {
+			CustomerRef: { value: 'QBO-CUST-002', name: 'John Lee' },
+			Line: [
+				{
+					Amount: 500.0,
+					DetailType: 'SalesItemLineDetail',
+					Description: 'Monthly Common Charge',
+					SalesItemLineDetail: {
+						ItemRef: { value: '1', name: 'HOA Common Charge' },
+						UnitPrice: 500.0,
+						Qty: 1,
+					},
+				},
+				{
+					Amount: 100.0,
+					DetailType: 'SalesItemLineDetail',
+					Description: 'Special Assessment',
+					SalesItemLineDetail: {
+						ItemRef: { value: '2', name: 'Special Assessment' },
+						UnitPrice: 100.0,
+						Qty: 1,
+					},
+				},
+			],
+			DueDate: '2026-03-01',
+			BillEmail: { Address: 'john.lee@test.com' },
+		},
+	},
+	{
+		Id: 'RT-003',
+		SyncToken: '0',
+		MetaData: {
+			CreateTime: '2024-02-01T08:00:00Z',
+			LastUpdatedTime: '2025-06-01T09:00:00Z',
+		},
+		RecurringInfo: {
+			Name: 'Quarterly Vendor Bill',
+			RecurType: 'Reminded',
+			Active: false,
+			ScheduleInfo: {
+				IntervalType: 'Monthly',
+				NumInterval: 3,
+				DayOfMonth: 15,
+				StartDate: '2024-01-15',
+				NextDate: '2024-04-15',
+				MaxOccurrences: 4,
+				DaysBefore: 5,
+			},
+		},
+		Bill: {
+			VendorRef: { value: '45', name: 'Office Depot' },
+			Line: [
+				{
+					Id: '1',
+					Description: 'Office Supplies',
+					Amount: 250.0,
+					DetailType: 'AccountBasedExpenseLineDetail',
+					AccountBasedExpenseLineDetail: {
+						AccountRef: { value: '70', name: 'Office Supplies' },
+					},
+				},
+			],
+			DueDate: '2024-02-15',
+			TotalAmt: 250.0,
+		},
+	},
+];

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -64,3 +64,4 @@ export { mockCreditMemoData } from './__mocks__/credit-memo-data';
 export { mockPaymentData } from './__mocks__/payment-data';
 export { mockAccountData } from './__mocks__/account-data';
 export { mockBillData } from './__mocks__/bill-data';
+export { mockRecurringTransactionData } from './__mocks__/recurring-transaction-data';

--- a/__tests__/recurring-transaction.test.ts
+++ b/__tests__/recurring-transaction.test.ts
@@ -1,0 +1,262 @@
+import { ApiClient } from '../src/app';
+import { AuthProvider, Environment, AuthScopes, RecurringTransaction } from '../src/app';
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { mockFetch, mockRecurringTransactionData, mockTokenData } from './helpers';
+
+// Mock configuration
+const TEST_CONFIG = {
+	clientId: 'test_client_id',
+	clientSecret: 'test_client_secret',
+	redirectUri: 'http://localhost:3000/auth-code',
+	scopes: [AuthScopes.Accounting],
+};
+
+describe('RecurringTransaction API', () => {
+	let apiClient: ApiClient;
+	let globalFetch: typeof fetch;
+
+	beforeEach(async () => {
+		globalFetch = global.fetch;
+		const authProvider = new AuthProvider(TEST_CONFIG.clientId, TEST_CONFIG.clientSecret, TEST_CONFIG.redirectUri, TEST_CONFIG.scopes);
+		await authProvider.setToken(mockTokenData);
+		apiClient = new ApiClient(authProvider, Environment.Sandbox);
+	});
+
+	afterEach(() => {
+		global.fetch = globalFetch;
+	});
+
+	describe('getAllRecurringTransactions', () => {
+		it('should fetch all recurring transactions', async () => {
+			const queryResponse = {
+				QueryResponse: {
+					RecurringTransaction: mockRecurringTransactionData,
+					maxResults: mockRecurringTransactionData.length,
+					startPosition: 1,
+					totalCount: mockRecurringTransactionData.length,
+				},
+			};
+
+			global.fetch = mockFetch(JSON.stringify(queryResponse));
+
+			const searchResponse = await apiClient.recurringTransactions.getAllRecurringTransactions();
+
+			expect(searchResponse.results).toBeArray();
+			expect(searchResponse.results.length).toBe(mockRecurringTransactionData.length);
+			searchResponse.results.forEach((rt, index) => {
+				expect(rt.Id).toBe(mockRecurringTransactionData[index].Id);
+			});
+		});
+
+		it('should handle search options', async () => {
+			const subset = mockRecurringTransactionData.slice(0, 2);
+			const queryResponse = {
+				QueryResponse: {
+					RecurringTransaction: subset,
+					maxResults: 2,
+					startPosition: 1,
+					totalCount: subset.length,
+				},
+			};
+
+			global.fetch = mockFetch(JSON.stringify(queryResponse));
+
+			const searchResponse = await apiClient.recurringTransactions.getAllRecurringTransactions({
+				searchOptions: { maxResults: 2, page: 1 },
+			});
+
+			expect(searchResponse.results).toBeArray();
+			expect(searchResponse.results.length).toBe(2);
+		});
+	});
+
+	describe('getRecurringTransactionById', () => {
+		it('should fetch recurring transaction by ID', async () => {
+			const testRT = mockRecurringTransactionData[0];
+			const queryResponse = {
+				QueryResponse: {
+					RecurringTransaction: [testRT],
+					maxResults: 1,
+					startPosition: 1,
+					totalCount: 1,
+				},
+			};
+
+			global.fetch = mockFetch(JSON.stringify(queryResponse));
+
+			const result = await apiClient.recurringTransactions.getRecurringTransactionById(testRT.Id!);
+
+			expect(result).toBeObject();
+			expect(result).toHaveProperty('recurringTransaction');
+			expect(result).toHaveProperty('intuitTID');
+			expect(typeof result.intuitTID).toBe('string');
+			expect(result.intuitTID).toBe('test-tid-12345-67890');
+			expect(result.recurringTransaction).toBeObject();
+			expect(result.recurringTransaction?.Id).toBe(testRT.Id);
+
+			if (result.recurringTransaction) {
+				expect(result.recurringTransaction).toBeInstanceOf(RecurringTransaction);
+				expect(typeof result.recurringTransaction.setApiClient).toBe('function');
+				expect(typeof result.recurringTransaction.reload).toBe('function');
+				expect(typeof result.recurringTransaction.save).toBe('function');
+				expect(typeof result.recurringTransaction.delete).toBe('function');
+			}
+		});
+
+		it('should throw error for invalid recurring transaction ID', async () => {
+			global.fetch = mockFetch(
+				JSON.stringify({
+					QueryResponse: {},
+					fault: { error: [{ message: 'RecurringTransaction not found' }] },
+				}),
+				400,
+			);
+
+			expect(apiClient.recurringTransactions.getRecurringTransactionById('-1')).rejects.toThrow('Failed to run request');
+		});
+	});
+
+	describe('getUpdatedRecurringTransactions', () => {
+		it('should fetch updated recurring transactions', async () => {
+			const lastUpdatedTime = new Date('2024-06-01');
+
+			const updated = mockRecurringTransactionData.filter((rt) => {
+				if (!rt.MetaData?.LastUpdatedTime) return false;
+				const rtDate = new Date(rt.MetaData.LastUpdatedTime);
+				return rtDate >= lastUpdatedTime;
+			});
+
+			const queryResponse = {
+				QueryResponse: {
+					RecurringTransaction: updated,
+					maxResults: updated.length,
+					startPosition: 1,
+					totalCount: updated.length,
+				},
+			};
+
+			global.fetch = mockFetch(JSON.stringify(queryResponse));
+
+			const searchResponse = await apiClient.recurringTransactions.getUpdatedRecurringTransactions(lastUpdatedTime);
+
+			expect(searchResponse.results).toBeArray();
+			expect(searchResponse.results.length).toBe(updated.length);
+		});
+	});
+
+	describe('rawRecurringTransactionQuery', () => {
+		it('should execute raw query', async () => {
+			const queryResponse = {
+				QueryResponse: {
+					RecurringTransaction: mockRecurringTransactionData,
+					maxResults: mockRecurringTransactionData.length,
+					startPosition: 1,
+					totalCount: mockRecurringTransactionData.length,
+				},
+			};
+
+			global.fetch = mockFetch(JSON.stringify(queryResponse));
+
+			const queryBuilder = await apiClient.recurringTransactions.getQueryBuilder();
+			const searchResponse = await apiClient.recurringTransactions.rawRecurringTransactionQuery(queryBuilder);
+
+			expect(searchResponse.results).toBeArray();
+			expect(searchResponse.results.length).toBe(mockRecurringTransactionData.length);
+			expect(searchResponse.results[0].Id).toBe(mockRecurringTransactionData[0].Id);
+		});
+	});
+
+	describe('RecurringTransaction Class', () => {
+		afterEach(() => {
+			global.fetch = globalFetch;
+		});
+
+		it('should return RecurringTransaction class instance with correct properties', async () => {
+			const testRT = mockRecurringTransactionData[0];
+			const queryResponse = {
+				QueryResponse: {
+					RecurringTransaction: [testRT],
+					maxResults: 1,
+					startPosition: 1,
+					totalCount: 1,
+				},
+			};
+			global.fetch = mockFetch(JSON.stringify(queryResponse));
+
+			const result = await apiClient.recurringTransactions.getRecurringTransactionById(testRT.Id!);
+
+			expect(result.recurringTransaction).toBeInstanceOf(RecurringTransaction);
+			expect(result.recurringTransaction?.RecurringInfo.Name).toBe('Monthly HOA Invoice - Unit 2A');
+			expect(result.recurringTransaction?.RecurringInfo.RecurType).toBe('Automated');
+			expect(result.recurringTransaction?.RecurringInfo.ScheduleInfo.IntervalType).toBe('Monthly');
+			expect(result.recurringTransaction?.Invoice?.CustomerRef.value).toBe('QBO-CUST-001');
+		});
+
+		it('should save recurring transaction', async () => {
+			const testRT = mockRecurringTransactionData[0];
+			const queryResponse = {
+				QueryResponse: {
+					RecurringTransaction: [testRT],
+					maxResults: 1,
+					startPosition: 1,
+					totalCount: 1,
+				},
+			};
+			global.fetch = mockFetch(JSON.stringify(queryResponse));
+
+			const result = await apiClient.recurringTransactions.getRecurringTransactionById(testRT.Id!);
+			const rt = result.recurringTransaction!;
+
+			rt.RecurringInfo.Name = 'Updated Template Name';
+
+			const saveResponse = { RecurringTransaction: { ...testRT, RecurringInfo: { ...testRT.RecurringInfo, Name: 'Updated Template Name' } } };
+			global.fetch = mockFetch(JSON.stringify(saveResponse));
+
+			await rt.save();
+
+			expect(global.fetch).toBeDefined();
+		});
+
+		it('should delete recurring transaction', async () => {
+			const testRT = mockRecurringTransactionData[0];
+			const queryResponse = {
+				QueryResponse: {
+					RecurringTransaction: [testRT],
+					maxResults: 1,
+					startPosition: 1,
+					totalCount: 1,
+				},
+			};
+			global.fetch = mockFetch(JSON.stringify(queryResponse));
+
+			const result = await apiClient.recurringTransactions.getRecurringTransactionById(testRT.Id!);
+			const rt = result.recurringTransaction!;
+
+			global.fetch = mockFetch(JSON.stringify({}));
+
+			await rt.delete();
+
+			expect(global.fetch).toBeDefined();
+		});
+
+		it('should throw error when deleting without ID', async () => {
+			const testRT = mockRecurringTransactionData[0];
+			const queryResponse = {
+				QueryResponse: {
+					RecurringTransaction: [testRT],
+					maxResults: 1,
+					startPosition: 1,
+					totalCount: 1,
+				},
+			};
+			global.fetch = mockFetch(JSON.stringify(queryResponse));
+
+			const result = await apiClient.recurringTransactions.getRecurringTransactionById(testRT.Id!);
+			const rt = result.recurringTransaction!;
+
+			(rt as any).Id = null;
+
+			await expect(rt.delete()).rejects.toThrow('RecurringTransaction must be saved before deleting');
+		});
+	});
+});

--- a/src/packages/api/api-client.ts
+++ b/src/packages/api/api-client.ts
@@ -18,6 +18,7 @@ import { PreferenceAPI } from './preferences/preference-api';
 import { CreditMemoAPI } from './credit-memo/credit-memo-api';
 import { CompanyInfoAPI } from './company-info/company-info-api';
 import { BillAPI } from './bill/bill-api';
+import { RecurringTransactionAPI } from './recurring-transaction/recurring-transaction-api';
 
 /**
  * API Client
@@ -68,6 +69,11 @@ export class ApiClient {
 	public bills: BillAPI;
 
 	/**
+	 * RecurringTransactions API
+	 */
+	public recurringTransactions: RecurringTransactionAPI;
+
+	/**
 	 * Automatically check for a next page (This creates an extra query to the API to check if there is a next page)
 	 */
 	public autoCheckNextPage: boolean = true;
@@ -88,6 +94,7 @@ export class ApiClient {
 		this.creditMemos = new CreditMemoAPI(this);
 		this.companyInfo = new CompanyInfoAPI(this);
 		this.bills = new BillAPI(this);
+		this.recurringTransactions = new RecurringTransactionAPI(this);
 	}
 
 	/**

--- a/src/packages/api/recurring-transaction/recurring-transaction-api.ts
+++ b/src/packages/api/recurring-transaction/recurring-transaction-api.ts
@@ -1,0 +1,129 @@
+import { ApiClient } from '../api-client';
+import { Environment, Query, QuickbooksError, type RecurringTransaction, type RecurringTransactionQueryResponse } from '../../../types/types';
+import { RecurringTransactionQueryBuilder } from './recurring-transaction-query-builder';
+import path from 'path';
+
+// Import the Services
+import { getAllRecurringTransactions } from './services/get-all-recurring-transactions';
+import { getRecurringTransactionById } from './services/get-recurring-transaction-by-id';
+import { getUpdatedRecurringTransactions } from './services/get-updated-recurring-transactions';
+import { rawRecurringTransactionQuery } from './services/raw-recurring-transaction-query';
+
+/**
+ * RecurringTransaction API Client
+ */
+export class RecurringTransactionAPI {
+	// The List of RecurringTransaction Services
+	public readonly getAllRecurringTransactions = getAllRecurringTransactions.bind(this);
+	public readonly getRecurringTransactionById = getRecurringTransactionById.bind(this);
+	public readonly getUpdatedRecurringTransactions = getUpdatedRecurringTransactions.bind(this);
+	public readonly rawRecurringTransactionQuery = rawRecurringTransactionQuery.bind(this);
+
+	/**
+	 * Constructor
+	 * @param apiClient - The API Client
+	 */
+	constructor(protected readonly apiClient: ApiClient) {}
+
+	/**
+	 * Get the Company Endpoint
+	 * @returns The Company Endpoint
+	 */
+	protected async getCompanyEndpoint(): Promise<string> {
+		// Get the Token
+		const token = await this.apiClient.authProvider.getToken();
+
+		// Get the Environment URL
+		const environmentUrl =
+			this.apiClient.environment === Environment.Production ? 'quickbooks.api.intuit.com' : 'sandbox-quickbooks.api.intuit.com';
+
+		// Return the Company Endpoint
+		return `https://${environmentUrl}/v3/company/${token.realmId}`;
+	}
+
+	/**
+	 * Format the Response
+	 * @param response - The Response
+	 * @returns The RecurringTransactions
+	 */
+	protected async formatResponse(response: any): Promise<Array<RecurringTransaction>> {
+		// Check if the Response is invalid
+		if (!response?.QueryResponse) {
+			// Get the Intuit Error Details
+			const errorDetails = await ApiClient.getIntuitErrorDetails(response);
+
+			// Throw the Quickbooks Error
+			throw new QuickbooksError('Unable to format RecurringTransactions', errorDetails);
+		}
+
+		// Check if the Length is Less than 1 and if it is, set to an empty array
+		if (!response.QueryResponse.RecurringTransaction) response.QueryResponse.RecurringTransaction = new Array();
+
+		// Get the RecurringTransactions
+		const queryResponse = response.QueryResponse as RecurringTransactionQueryResponse;
+
+		// Return the RecurringTransactions
+		return queryResponse.RecurringTransaction;
+	}
+
+	// Returns the RecurringTransaction URL
+	public async getUrl() {
+		// Setup the URL
+		const url = new URL(await this.getCompanyEndpoint());
+
+		// Set the RecurringTransaction Endpoint
+		url.pathname = path.join(url.pathname, 'recurringtransaction');
+
+		// Return the URL
+		return url;
+	}
+
+	/**
+	 * Get the Query Builder
+	 * @returns The Query Builder
+	 */
+	public async getQueryBuilder(): Promise<RecurringTransactionQueryBuilder> {
+		// Get the Company Endpoint
+		const companyEndpoint = await this.getCompanyEndpoint();
+
+		// Setup the New Query Builder
+		const queryBuilder = new RecurringTransactionQueryBuilder(companyEndpoint, Query.RecurringTransaction);
+
+		// Return the Query Builder
+		return queryBuilder;
+	}
+
+	/**
+	 * Checks if there is a next page
+	 * @param queryBuilder - The Query Builder
+	 * @returns True if there is a next page
+	 */
+	protected async hasNextPage(queryBuilder: RecurringTransactionQueryBuilder): Promise<boolean> {
+		// Check if Auto Check Next Page is Disabled
+		if (!this.apiClient.autoCheckNextPage) return false;
+
+		// Get the Page Number
+		const page = (queryBuilder.searchOptions.page || 1) + 1;
+
+		// Update the Page Number
+		queryBuilder.searchOptions.page = page;
+
+		// Get the URL
+		const url = queryBuilder.build();
+
+		// Run the Request
+		const result = await this.apiClient.runRequest(url, { method: 'GET' }).catch((error) => {
+			console.error(`Failed to check if there is a next page: ${error}`);
+			return null;
+		});
+
+		// Check if the Response is Invalid
+		if (!result?.responseData || !result.responseData?.QueryResponse?.RecurringTransaction) return false;
+
+		// Check if the Response has no RecurringTransactions
+		if (result.responseData.QueryResponse.RecurringTransaction.length < 1) return false;
+
+		// Return True
+		return true;
+	}
+}

--- a/src/packages/api/recurring-transaction/recurring-transaction-query-builder.ts
+++ b/src/packages/api/recurring-transaction/recurring-transaction-query-builder.ts
@@ -1,0 +1,8 @@
+// Imports
+import type { RecurringTransaction } from '../../../types/types';
+import { BaseQueryBuilder } from '../common/base-query-builder';
+
+/**
+ * The RecurringTransaction Query Builder
+ */
+export class RecurringTransactionQueryBuilder extends BaseQueryBuilder<RecurringTransaction> {}

--- a/src/packages/api/recurring-transaction/services/get-all-recurring-transactions.ts
+++ b/src/packages/api/recurring-transaction/services/get-all-recurring-transactions.ts
@@ -1,0 +1,38 @@
+import type { RecurringTransaction, RecurringTransactionOptions, SearchResponse } from '../../../../types/types';
+import { RecurringTransactionAPI } from '../recurring-transaction-api';
+
+/**
+ * Get All RecurringTransactions
+ * @param this - The RecurringTransaction API
+ * @param options - The options
+ * @returns The RecurringTransactions
+ */
+export async function getAllRecurringTransactions(
+	this: RecurringTransactionAPI,
+	options: RecurringTransactionOptions = {},
+): Promise<SearchResponse<RecurringTransaction>> {
+	// Get the Query Builder
+	const queryBuilder = await this.getQueryBuilder();
+
+	// Setup the Search Options
+	if (options.searchOptions) queryBuilder.setSearchOptions(options.searchOptions);
+
+	// Build the URL
+	const url = queryBuilder.build();
+
+	// Get the RecurringTransactions
+	const { responseData, intuitTID } = await this.apiClient.runRequest(url, { method: 'GET' });
+
+	// Format the Response
+	const recurringTransactions = await this.formatResponse(responseData);
+
+	// Setup the Search Response
+	const searchResponse: SearchResponse<RecurringTransaction> = {
+		results: recurringTransactions,
+		hasNextPage: await this.hasNextPage(queryBuilder),
+		intuitTID,
+	};
+
+	// Return the Search Response
+	return searchResponse;
+}

--- a/src/packages/api/recurring-transaction/services/get-recurring-transaction-by-id.ts
+++ b/src/packages/api/recurring-transaction/services/get-recurring-transaction-by-id.ts
@@ -1,0 +1,45 @@
+// Import the Query Builder
+import { plainToClass } from 'class-transformer';
+import { RecurringTransaction } from '../../../../types/types';
+import { RecurringTransactionAPI } from '../recurring-transaction-api';
+
+/**
+ * Get RecurringTransaction by ID
+ * @param this - The RecurringTransaction API
+ * @param id - The ID of the recurring transaction
+ * @returns The RecurringTransaction
+ */
+export async function getRecurringTransactionById(
+	this: RecurringTransactionAPI,
+	id: string,
+): Promise<{ recurringTransaction: RecurringTransaction | null; intuitTID: string }> {
+	// Get the Query Builder
+	const queryBuilder = await this.getQueryBuilder();
+
+	// Setup ID Filter
+	queryBuilder.whereId(id);
+
+	// Setup the URL
+	const url = queryBuilder.build();
+
+	// Get the RecurringTransaction
+	const { responseData, intuitTID } = await this.apiClient.runRequest(url, { method: 'GET' });
+
+	// Check if the Response Failed to find a RecurringTransaction
+	if (!responseData) return { recurringTransaction: null, intuitTID };
+
+	// Format the Response
+	const recurringTransactions = await this.formatResponse(responseData);
+
+	// Convert the RecurringTransaction to a Class
+	const recurringTransaction = recurringTransactions[0] ? plainToClass(RecurringTransaction, recurringTransactions[0]) : null;
+
+	// Check if the RecurringTransaction is valid and set the API Client
+	if (recurringTransaction) recurringTransaction.setApiClient(this.apiClient);
+
+	// Return the RecurringTransaction with Intuit TID
+	return {
+		recurringTransaction,
+		intuitTID,
+	};
+}

--- a/src/packages/api/recurring-transaction/services/get-updated-recurring-transactions.ts
+++ b/src/packages/api/recurring-transaction/services/get-updated-recurring-transactions.ts
@@ -1,0 +1,43 @@
+// Import the Query Builder
+import type { RecurringTransaction, RecurringTransactionOptions, SearchResponse } from '../../../../types/types';
+import { RecurringTransactionAPI } from '../recurring-transaction-api';
+
+/**
+ * Get Updated RecurringTransactions
+ * @param this - The RecurringTransaction API
+ * @param lastUpdatedDate - The last updated date
+ * @returns The RecurringTransactions
+ */
+export async function getUpdatedRecurringTransactions(
+	this: RecurringTransactionAPI,
+	lastUpdatedDate: Date,
+	options: RecurringTransactionOptions = {},
+): Promise<SearchResponse<RecurringTransaction>> {
+	// Get the Query Builder
+	const queryBuilder = await this.getQueryBuilder();
+
+	// Setup the Last Updated Date Filter
+	queryBuilder.whereLastUpdatedAfter(lastUpdatedDate);
+
+	// Setup the Search Options (if provided)
+	if (options.searchOptions) queryBuilder.setSearchOptions(options.searchOptions);
+
+	// Setup the URL
+	const url = queryBuilder.build();
+
+	// Get the RecurringTransactions
+	const { responseData, intuitTID } = await this.apiClient.runRequest(url, { method: 'GET' });
+
+	// Format the Response
+	const recurringTransactions = await this.formatResponse(responseData);
+
+	// Setup the Search Response
+	const searchResponse: SearchResponse<RecurringTransaction> = {
+		results: recurringTransactions,
+		hasNextPage: await this.hasNextPage(queryBuilder),
+		intuitTID,
+	};
+
+	// Return the RecurringTransactions
+	return searchResponse;
+}

--- a/src/packages/api/recurring-transaction/services/raw-recurring-transaction-query.ts
+++ b/src/packages/api/recurring-transaction/services/raw-recurring-transaction-query.ts
@@ -1,0 +1,34 @@
+// Import the Query Builder
+import { RecurringTransactionAPI } from '../recurring-transaction-api';
+import type { RecurringTransactionQueryBuilder } from '../recurring-transaction-query-builder';
+import type { RecurringTransaction, SearchResponse } from '../../../../types/types';
+
+/**
+ * Raw RecurringTransaction Query
+ * @param this - The RecurringTransaction API
+ * @param queryBuilder - The query builder to use
+ * @returns Custom query results
+ */
+export async function rawRecurringTransactionQuery(
+	this: RecurringTransactionAPI,
+	queryBuilder: RecurringTransactionQueryBuilder,
+): Promise<SearchResponse<RecurringTransaction>> {
+	// Build the URL
+	const url = queryBuilder.build();
+
+	// Execute the custom query
+	const { responseData, intuitTID } = await this.apiClient.runRequest(url, { method: 'GET' });
+
+	// Format the Response
+	const recurringTransactions = await this.formatResponse(responseData);
+
+	// Setup the Search Response
+	const searchResponse: SearchResponse<RecurringTransaction> = {
+		results: recurringTransactions,
+		hasNextPage: await this.hasNextPage(queryBuilder),
+		intuitTID,
+	};
+
+	// Return the RecurringTransactions
+	return searchResponse;
+}

--- a/src/types/classes/recurring-transaction.ts
+++ b/src/types/classes/recurring-transaction.ts
@@ -1,0 +1,177 @@
+// Import the Types
+import { ApiClient } from '../../packages/api/api-client';
+import { QuickbooksError, type ModificationMetadata } from '../types';
+import type { RecurringInfo, RecurringInvoice, RecurringBill } from '../interfaces/recurring-transaction';
+
+/**
+ * RecurringTransaction
+ *
+ * @description The RecurringTransaction Object — a template that QBO uses to
+ * automatically (or on reminder) create recurring invoices, bills, etc.
+ *
+ * @see {@link https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/recurringtransaction}
+ */
+export class RecurringTransaction {
+	/**
+	 * @description The API client used to make requests to the API
+	 */
+	private apiClient: ApiClient;
+
+	// Readonly / system-defined properties
+	/**
+	 * @description Unique identifier for this object
+	 * @readonly @systemDefined
+	 * @requiredForUpdate
+	 */
+	public readonly Id: string;
+
+	/**
+	 * @description Version number for update tracking
+	 * @readonly @systemDefined
+	 * @requiredForUpdate
+	 */
+	public readonly SyncToken: string;
+
+	/**
+	 * @description System-defined metadata. Read-only
+	 */
+	public readonly MetaData?: ModificationMetadata;
+
+	// Required properties
+	/**
+	 * @description Schedule and recurrence configuration
+	 */
+	public RecurringInfo: RecurringInfo;
+
+	// Polymorphic transaction — exactly one will be set
+	/**
+	 * @description Invoice template (present when the recurring transaction wraps an Invoice)
+	 */
+	public Invoice?: RecurringInvoice;
+
+	/**
+	 * @description Bill template (present when the recurring transaction wraps a Bill)
+	 */
+	public Bill?: RecurringBill;
+
+	// Optional properties
+	/**
+	 * @description Domain of the data source
+	 */
+	public domain?: string;
+
+	/**
+	 * @description Sparse update flag
+	 */
+	public sparse?: boolean;
+
+	/**
+	 * @description Constructor for RecurringTransaction
+	 * @param apiClient - The API client
+	 * @param creationData - The data for the recurring transaction
+	 */
+	constructor(apiClient: ApiClient, creationData: RecurringTransactionCreationData) {
+		// Set the API Client
+		this.apiClient = apiClient;
+
+		// Initialize the System Defined Properties
+		this.Id = null!;
+		this.SyncToken = null!;
+
+		// Build the Required Properties
+		this.RecurringInfo = creationData?.RecurringInfo ?? null!;
+		this.Invoice = creationData?.Invoice;
+		this.Bill = creationData?.Bill;
+	}
+
+	/**
+	 * @description Set the API Client
+	 * @param apiClient - The API client
+	 */
+	public setApiClient(apiClient: ApiClient) {
+		this.apiClient = apiClient;
+	}
+
+	/**
+	 * @description Reload the RecurringTransaction Data
+	 * @throws {QuickbooksError} If the RecurringTransaction was not found
+	 */
+	public async reload() {
+		// Get the RecurringTransaction by ID
+		const result = await this.apiClient.recurringTransactions.getRecurringTransactionById(this.Id);
+
+		// Check if the RecurringTransaction was not Found
+		if (!result.recurringTransaction)
+			throw new QuickbooksError('RecurringTransaction not found', await ApiClient.getIntuitErrorDetails(null));
+
+		// Assign the Properties
+		Object.assign(this, result.recurringTransaction);
+	}
+
+	/**
+	 * @description Custom JSON serialization to exclude private properties
+	 */
+	private toJSON() {
+		// Setup the Excluded Properties
+		const excludedProperties = ['apiClient'];
+
+		// Setup the JSON Object
+		const jsonData = { ...Object.fromEntries(Object.entries(this).filter(([key]) => !excludedProperties.includes(key))) };
+
+		// Return the JSON Object
+		return jsonData;
+	}
+
+	/**
+	 * @description Updates or creates (if the Id is not set) the RecurringTransaction
+	 */
+	public async save() {
+		// Get the RecurringTransaction URL
+		const url = await this.apiClient.recurringTransactions.getUrl();
+
+		// Setup the Request Data
+		const requestData: RequestInit = {
+			method: 'POST',
+			body: JSON.stringify({ ...this.toJSON(), sparse: true }),
+		};
+
+		// Update the RecurringTransaction
+		const { responseData } = await this.apiClient.runRequest(url.href, requestData);
+
+		// Extract the RecurringTransaction from the response
+		const data = responseData?.RecurringTransaction?.[0] || responseData?.RecurringTransaction || responseData;
+
+		// Assign the Properties
+		Object.assign(this, data);
+	}
+
+	/**
+	 * @description Deletes the RecurringTransaction
+	 * @throws {QuickbooksError} If the RecurringTransaction ID is not set
+	 */
+	public async delete() {
+		// Check if the RecurringTransaction has an ID
+		if (!this.Id)
+			throw new QuickbooksError('RecurringTransaction must be saved before deleting', await ApiClient.getIntuitErrorDetails(null));
+
+		// Get the RecurringTransaction URL and append operation=delete
+		const url = await this.apiClient.recurringTransactions.getUrl();
+		url.searchParams.set('operation', 'delete');
+
+		// Setup the Request Data
+		const requestData: RequestInit = {
+			method: 'POST',
+			body: JSON.stringify({ Id: this.Id, SyncToken: this.SyncToken }),
+		};
+
+		// Delete the RecurringTransaction
+		await this.apiClient.runRequest(url.href, requestData);
+	}
+}
+
+// Setup the Creation Data
+export type RecurringTransactionCreationData = {
+	RecurringInfo: RecurringInfo;
+	Invoice?: RecurringInvoice;
+	Bill?: RecurringBill;
+};

--- a/src/types/enums/query.ts
+++ b/src/types/enums/query.ts
@@ -11,4 +11,5 @@ export enum Query {
 	Account = 'select * from account',
 	CompanyInfo = 'select * from companyinfo',
 	Bill = 'select * from Bill',
+	RecurringTransaction = 'select * from RecurringTransaction',
 }

--- a/src/types/interfaces/options.ts
+++ b/src/types/interfaces/options.ts
@@ -10,6 +10,7 @@ import {
 	InvoiceStatus,
 	Payment,
 	Preferences,
+	RecurringTransaction,
 	SearchOptions,
 } from '../types';
 
@@ -41,6 +42,9 @@ export interface PreferenceOptions extends Options<Preferences> {}
 
 // Setup the Bill Options
 export interface BillOptions extends Options<Bill> {}
+
+// Setup the RecurringTransaction Options
+export interface RecurringTransactionOptions extends Options<RecurringTransaction> {}
 
 // Export the Options
 export interface Options<T> {

--- a/src/types/interfaces/query-response.ts
+++ b/src/types/interfaces/query-response.ts
@@ -1,5 +1,5 @@
 // Imports
-import type { Estimate, Customer, Invoice, Payment, Account, CreditMemo, Preferences, CompanyInfo, Bill } from '../types';
+import type { Estimate, Customer, Invoice, Payment, Account, CreditMemo, Preferences, CompanyInfo, Bill, RecurringTransaction } from '../types';
 
 /**
  * The Invoice Query Response
@@ -61,6 +61,13 @@ export interface EstimateQueryResponse extends QueryResponse {
  */
 export interface BillQueryResponse extends QueryResponse {
 	Bill: Array<Bill>;
+}
+
+/**
+ * The RecurringTransaction Query Response
+ */
+export interface RecurringTransactionQueryResponse extends QueryResponse {
+	RecurringTransaction: Array<RecurringTransaction>;
 }
 
 /**

--- a/src/types/interfaces/recurring-transaction.ts
+++ b/src/types/interfaces/recurring-transaction.ts
@@ -1,0 +1,179 @@
+import type {
+	ReferenceType,
+	SalesItemLine,
+	GroupLine,
+	DescriptionOnlyLine,
+	DiscountLine,
+	SubTotalLine,
+	ModificationMetadata,
+	EmailAddress,
+	PhysicalAddress,
+	TxnTaxDetail,
+	CustomField,
+	LinkedTxn,
+} from '../types';
+import type { BillLine } from '../classes/bill';
+
+/**
+ * Recurring transaction type — which underlying entity this template wraps
+ */
+export type RecurringTxnType = 'Invoice' | 'Bill' | 'SalesReceipt' | 'CreditMemo' | 'Estimate' | 'Purchase' | 'Deposit' | 'RefundReceipt' | 'JournalEntry' | 'VendorCredit' | 'Transfer';
+
+/**
+ * How QBO handles the recurring transaction
+ */
+export type RecurType = 'Automated' | 'Reminded' | 'Unscheduled';
+
+/**
+ * Schedule interval type
+ */
+export type IntervalType = 'Daily' | 'Weekly' | 'Monthly' | 'Yearly';
+
+/**
+ * Schedule configuration for recurring transactions
+ */
+export interface ScheduleInfo {
+	/**
+	 * Schedule interval type
+	 */
+	IntervalType: IntervalType;
+
+	/**
+	 * Number of intervals between occurrences
+	 */
+	NumInterval: number;
+
+	/**
+	 * Day of month (1–31) for Monthly schedules
+	 */
+	DayOfMonth?: number;
+
+	/**
+	 * Day of week for Weekly schedules
+	 */
+	DayOfWeek?: string;
+
+	/**
+	 * Start date (yyyy-MM-dd)
+	 */
+	StartDate: string;
+
+	/**
+	 * Next scheduled date (yyyy-MM-dd, system-managed)
+	 */
+	NextDate?: string;
+
+	/**
+	 * End date (yyyy-MM-dd, optional)
+	 */
+	EndDate?: string;
+
+	/**
+	 * Maximum number of occurrences (0 = unlimited)
+	 */
+	MaxOccurrences?: number;
+
+	/**
+	 * Days before due date to create the transaction
+	 */
+	DaysBefore?: number;
+}
+
+/**
+ * Recurring schedule configuration
+ */
+export interface RecurringInfo {
+	/**
+	 * Template name displayed in QBO
+	 */
+	Name: string;
+
+	/**
+	 * How the schedule is processed
+	 */
+	RecurType: RecurType;
+
+	/**
+	 * Whether the schedule is active
+	 */
+	Active: boolean;
+
+	/**
+	 * Schedule timing configuration
+	 */
+	ScheduleInfo: ScheduleInfo;
+}
+
+/**
+ * Invoice fields used inside a recurring transaction template
+ */
+export interface RecurringInvoice {
+	Id?: string;
+	SyncToken?: string;
+	MetaData?: ModificationMetadata;
+	CustomerRef: ReferenceType;
+	Line: Array<SalesItemLine | GroupLine | DescriptionOnlyLine | DiscountLine | SubTotalLine>;
+	DueDate?: string;
+	TxnDate?: string;
+	DocNumber?: string;
+	PrivateNote?: string;
+	BillEmail?: EmailAddress;
+	BillAddr?: PhysicalAddress;
+	ShipAddr?: PhysicalAddress;
+	DepartmentRef?: ReferenceType;
+	SalesTermRef?: ReferenceType;
+	TxnTaxDetail?: TxnTaxDetail;
+	CustomField?: CustomField;
+	LinkedTxn?: LinkedTxn[];
+	CurrencyRef?: ReferenceType;
+	AllowOnlineACHPayment?: boolean;
+	AllowOnlineCreditCardPayment?: boolean;
+	CustomerMemo?: { value: string };
+	TotalAmt?: number;
+	Balance?: number;
+	domain?: string;
+	sparse?: boolean;
+}
+
+/**
+ * Bill fields used inside a recurring transaction template
+ */
+export interface RecurringBill {
+	Id?: string;
+	SyncToken?: string;
+	MetaData?: ModificationMetadata;
+	VendorRef: ReferenceType;
+	Line?: BillLine[];
+	DueDate?: string;
+	TxnDate?: string;
+	DocNumber?: string;
+	PrivateNote?: string;
+	APAccountRef?: ReferenceType;
+	SalesTermRef?: ReferenceType;
+	TxnTaxDetail?: TxnTaxDetail;
+	CurrencyRef?: ReferenceType;
+	DepartmentRef?: ReferenceType;
+	TotalAmt?: number;
+	Balance?: number;
+	domain?: string;
+	sparse?: boolean;
+}
+
+/**
+ * The full RecurringTransaction object returned by QBO
+ *
+ * The transaction type is polymorphic — exactly one of Invoice, Bill, etc.
+ * will be present depending on TxnType.
+ */
+export interface RecurringTransactionData {
+	Id?: string;
+	SyncToken?: string;
+	MetaData?: ModificationMetadata;
+	RecurringInfo: RecurringInfo;
+
+	Invoice?: RecurringInvoice;
+	Bill?: RecurringBill;
+
+	domain?: string;
+	sparse?: boolean;
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -9,6 +9,8 @@ export { Estimate } from './classes/estimate';
 export { Payment } from './classes/payment';
 export { Preferences } from './classes/preferences';
 export { QuickbooksError } from './classes/quickbooks-error';
+export { RecurringTransaction } from './classes/recurring-transaction';
+export type { RecurringTransactionCreationData } from './classes/recurring-transaction';
 
 // Export the Enums
 export { APIUrls } from './enums/api-urls';
@@ -66,6 +68,7 @@ export type {
 	CreditMemoOptions,
 	PreferenceOptions,
 	BillOptions,
+	RecurringTransactionOptions,
 } from './interfaces/options';
 export type { Account as AccountInterface } from './interfaces/account';
 export type { CompanyInfo as CompanyInfoInterface } from './interfaces/company';
@@ -82,6 +85,7 @@ export type {
 	CreditMemoQueryResponse,
 	CompanyInfoQueryResponse,
 	BillQueryResponse,
+	RecurringTransactionQueryResponse,
 } from './interfaces/query-response';
 export type { ReferenceType } from './interfaces/reference-type';
 export type { SalesItemLineDetail } from './interfaces/sales-item-line-detail';
@@ -98,6 +102,16 @@ export type { TxnTaxDetail } from './interfaces/txn-tax-detail';
 export type { UserAuthResponse } from './interfaces/user-auth-response';
 export type { UserProfile } from './interfaces/user-profile';
 export type { WebsiteAddress } from './interfaces/website-address';
+export type {
+	RecurringTransactionData,
+	RecurringInfo,
+	ScheduleInfo,
+	RecurringInvoice,
+	RecurringBill,
+	RecurType,
+	IntervalType,
+	RecurringTxnType,
+} from './interfaces/recurring-transaction';
 
 // Export the Types
 export type { DeepKeys } from './types/deep-keys';


### PR DESCRIPTION
Add full CRUD support for QBO RecurringTransaction entities, following the existing sub-API pattern used by Invoice, Bill, Customer, etc.

This enables creating, reading, updating, and deleting recurring invoice/bill templates via the QBO API's /recurringtransaction endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for RecurringTransaction API functionality.

* **Chores**
  * Updated repository configuration to track distribution files in git.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->